### PR TITLE
fix Ant build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .classpath
 .settings
 bin/
+build
+dist

--- a/trunk/SwingSet3/nbproject/build-impl.xml
+++ b/trunk/SwingSet3/nbproject/build-impl.xml
@@ -1199,7 +1199,7 @@ is divided into following sections:
         <condition else="" property="bug5101868workaround" value="*.java">
             <matches pattern="1\.[56](\..*)?" string="${java.version}"/>
         </condition>
-        <javadoc additionalparam="-J-Dfile.encoding=${file.encoding} ${javadoc.additionalparam}" author="${javadoc.author}" charset="UTF-8" destdir="${dist.javadoc.dir}" docencoding="UTF-8" encoding="${javadoc.encoding.used}" failonerror="true" noindex="${javadoc.noindex}" nonavbar="${javadoc.nonavbar}" notree="${javadoc.notree}" private="${javadoc.private}" source="${javac.source}" splitindex="${javadoc.splitindex}" use="${javadoc.use}" useexternalfile="true" version="${javadoc.version}" windowtitle="${javadoc.windowtitle}">
+        <javadoc additionalparam="-J-Dfile.encoding=${file.encoding} ${javadoc.additionalparam}" author="${javadoc.author}" charset="UTF-8" destdir="${dist.javadoc.dir}" docencoding="UTF-8" encoding="${javadoc.encoding.used}" failonerror="false" noindex="${javadoc.noindex}" nonavbar="${javadoc.nonavbar}" notree="${javadoc.notree}" private="${javadoc.private}" source="${javac.source}" splitindex="${javadoc.splitindex}" use="${javadoc.use}" useexternalfile="true" version="${javadoc.version}" windowtitle="${javadoc.windowtitle}">
             <classpath>
                 <path path="${javac.classpath}"/>
             </classpath>

--- a/trunk/SwingSet3/nbproject/project.properties
+++ b/trunk/SwingSet3/nbproject/project.properties
@@ -69,6 +69,7 @@ javadoc.splitindex=true
 javadoc.use=true
 javadoc.version=false
 javadoc.windowtitle=
+jnlp.file=SwingSet3.jnlp
 main.class=com.sun.swingset3.SwingSet3
 manifest.file=manifest.mf
 meta.inf.dir=${src.dir}/META-INF

--- a/trunk/SwingSet3/src/com/sun/swingset3/Demo.java
+++ b/trunk/SwingSet3/src/com/sun/swingset3/Demo.java
@@ -34,13 +34,12 @@ package com.sun.swingset3;
 import java.awt.Component;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
 import java.util.logging.Level;
+
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 
@@ -61,7 +60,7 @@ public class Demo {
         return parts.length >= 2? parts[parts.length-2] : "general";
     }
     
-    public static String deriveCategoryFromPackageName(Class demoClass) {
+    public static String deriveCategoryFromPackageName(Class<?> demoClass) {
         String packageName = demoClass.getPackage() != null? 
             demoClass.getPackage().getName() : null;
         if (packageName != null) {
@@ -80,7 +79,7 @@ public class Demo {
         return convertToDemoName(simpleName);
     }
     
-    public static String deriveNameFromClassName(Class demoClass) {
+    public static String deriveNameFromClassName(Class<?> demoClass) {
         String className = demoClass.getSimpleName();
         return convertToDemoName(className);
     }
@@ -137,7 +136,7 @@ public class Demo {
         pcs = new PropertyChangeSupport(this);
     }
     
-    public Class getDemoClass() {
+    public Class<?> getDemoClass() {
         return demoClass;
     }
  
@@ -201,9 +200,10 @@ public class Demo {
             // If meta-data is not specified then sourceFilePaths contains
             // one empty string. In this case we skip it.
             if (!(sourceFilePaths.length == 1 && sourceFilePaths[0].length() == 0)) {
+                String currDir = System.getProperty("user.dir").replace("\\", "/").replaceFirst("^[A-Z]:", "");
                 for (String path : sourceFilePaths) {
                 	try {
-						URL url = new URL("file://" + System.getProperty("user.dir") + "/src/" + path);
+						URL url = new URL("file://" + currDir + "/src/" + path);
 						pathURLs.add(url);
 					} catch (MalformedURLException e) {
 						SwingSet3.logger.log(Level.WARNING,


### PR DESCRIPTION
so that the Ant build would complete successfully:

- add the missing jnlp.file property
- javadoc command shouldn't fail the build when there are errors in
javadocs (and there are plenty of javadoc errors!)
- make the source code loading work in Windows, by removing the
drive letter from the user.dir property value string when read.

This would make the Ant build succeeds and the resulting SwingSet3 works fine in Java 8.
The build would still succeed in Java 11, but SwingSet3 gives errors when switching between demos.
The fix for Java 11 will be in another PR.
